### PR TITLE
Fix #397: RVA scrubber fails for large assemblies where RVA is longer…

### DIFF
--- a/src/Verify.ICSharpCode.Decompiler/VerifyICSharpCodeDecompiler.cs
+++ b/src/Verify.ICSharpCode.Decompiler/VerifyICSharpCodeDecompiler.cs
@@ -7,7 +7,7 @@ namespace VerifyTests;
 
 public static class VerifyICSharpCodeDecompiler
 {
-    static readonly Regex RvaScrubber = new(@"[ \t]+// Method begins at RVA 0x\w{4}\r?\n");
+    static readonly Regex RvaScrubber = new(@"[ \t]+// Method begins at RVA 0x[0-9A-F]+\r?\n", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     public static void Enable()
     {


### PR DESCRIPTION
… than 4 digits - #397