### PR TITLE
Fix #413: PropertyToDisassemble can disassemble getter and setter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -356,6 +356,65 @@ Result:
 <sup><a href='/src/Tests/Tests.MethodNameUsage.verified.il#L1-L29' title='Snippet source file'>snippet source</a> | <a href='#snippet-Tests.MethodNameUsage.verified.il' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+### Verify Property
+<!-- snippet: PropertyPartsUsage -->
+<a id='snippet-propertypartsusage'></a>
+```cs
+[Test]
+public async Task PropertyPartsUsage()
+{
+    using var file = new PEFile(assemblyPath);
+    await Verify(
+        new PropertyToDisassemble(
+            file,
+            "Target",
+            "Property",
+            PropertyParts.GetterAndSetter));
+}
+```
+<sup><a href='/src/Tests/Tests.cs#L66-L80' title='Snippet source file'>snippet source</a> | <a href='#snippet-propertypartsusage' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Result:
+
+<!-- snippet: Tests.PropertyPartsUsage.verified.il -->
+<a id='snippet-Tests.PropertyPartsUsage.verified.il'></a>
+```il
+.method public hidebysig specialname 
+	instance string get_Property () cil managed 
+{
+	// Header size: 1
+	// Code size: 7 (0x7)
+	.maxstack 8
+
+	IL_0000: ldarg.0
+	IL_0001: ldfld string Target::'property'
+	IL_0006: ret
+} // end of method Target::get_Property
+.method public hidebysig specialname 
+	instance void set_Property (
+		string 'value'
+	) cil managed 
+{
+	// Header size: 1
+	// Code size: 21 (0x15)
+	.maxstack 8
+
+	IL_0000: nop
+	IL_0001: ldarg.0
+	IL_0002: ldarg.1
+	IL_0003: stfld string Target::'property'
+	IL_0008: ldarg.0
+	IL_0009: ldstr "Property"
+	IL_000e: call instance void Target::OnPropertyChanged(string)
+	IL_0013: nop
+	IL_0014: ret
+} // end of method Target::set_Property
+```
+<sup><a href='/src/Tests/Tests.PropertyPartsUsage.verified.il#L1-L30' title='Snippet source file'>snippet source</a> | <a href='#snippet-Tests.PropertyPartsUsage.verified.il' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+
 ### Settings
 
 Starting with version 3.2 the generated IL is normalized by default, to avoid failed tests only because the binary layout has changed:
@@ -376,7 +435,7 @@ public async Task BackwardCompatibility()
         .DontNormalizeIl();
 }
 ```
-<sup><a href='/src/Tests/Tests.cs#L168-L178' title='Snippet source file'>snippet source</a> | <a href='#snippet-backwardcompatibility' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Tests.cs#L184-L194' title='Snippet source file'>snippet source</a> | <a href='#snippet-backwardcompatibility' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Icon

--- a/src/Tests/Tests.PropertyNameMisMatch.verified.txt
+++ b/src/Tests/Tests.PropertyNameMisMatch.verified.txt
@@ -2,7 +2,7 @@
   Type: Exception,
   Message: Could not find `Target.Missing` in `{CurrentDirectory}Tests.dll`,
   StackTrace:
-at VerifyTests.ICSharpCode.Decompiler.Extensions.FindProperty(PEFile file, String typeName, String propertyName)
-at VerifyTests.PropertyToDisassemble..ctor(PEFile file, String typeName, String propertyName)
+at VerifyTests.ICSharpCode.Decompiler.Extensions.FindPropertyInfo(PEFile file, String typeName, String propertyName)
+at VerifyTests.PropertyToDisassemble..ctor(PEFile file, String typeName, String propertyName, PropertyParts partsToDisassemble)
 --- End of stack trace from previous location ---
 }

--- a/src/Tests/Tests.PropertyPartsUsage.verified.il
+++ b/src/Tests/Tests.PropertyPartsUsage.verified.il
@@ -1,0 +1,30 @@
+﻿.method public hidebysig specialname 
+	instance string get_Property () cil managed 
+{
+	// Header size: 1
+	// Code size: 7 (0x7)
+	.maxstack 8
+
+	IL_0000: ldarg.0
+	IL_0001: ldfld string Target::'property'
+	IL_0006: ret
+} // end of method Target::get_Property
+.method public hidebysig specialname 
+	instance void set_Property (
+		string 'value'
+	) cil managed 
+{
+	// Header size: 1
+	// Code size: 21 (0x15)
+	.maxstack 8
+
+	IL_0000: nop
+	IL_0001: ldarg.0
+	IL_0002: ldarg.1
+	IL_0003: stfld string Target::'property'
+	IL_0008: ldarg.0
+	IL_0009: ldstr "Property"
+	IL_000e: call instance void Target::OnPropertyChanged(string)
+	IL_0013: nop
+	IL_0014: ret
+} // end of method Target::set_Property

--- a/src/Tests/Tests.cs
+++ b/src/Tests/Tests.cs
@@ -63,6 +63,22 @@ public class Tests
 
     #endregion
 
+    #region PropertyPartsUsage
+
+    [Test]
+    public async Task PropertyPartsUsage()
+    {
+        using var file = new PEFile(assemblyPath);
+        await Verify(
+            new PropertyToDisassemble(
+                file,
+                "Target",
+                "Property",
+                PropertyParts.GetterAndSetter));
+    }
+
+    #endregion
+
     [Test]
     public async Task AssemblyUsage()
     {
@@ -161,7 +177,7 @@ public class Tests
 
         Assert.Throws<InvalidOperationException>(() => file.FindMethod("GenericTarget`1", "Overload", m => m.Parameters.Count == 2));
 
-        method = file.FindMethod("GenericTarget`1", "Overload", m => m.Parameters is [_, {Type.ReflectionName: "System.Double"}]);
+        method = file.FindMethod("GenericTarget`1", "Overload", m => m.Parameters is [_, { Type.ReflectionName: "System.Double" }]);
         Assert.True(method != default);
     }
 

--- a/src/Verify.ICSharpCode.Decompiler/Extensions.cs
+++ b/src/Verify.ICSharpCode.Decompiler/Extensions.cs
@@ -17,13 +17,16 @@ public static class Extensions
     public static TypeDefinitionHandle FindType(this PEFile file, string typeName) =>
         (TypeDefinitionHandle)FindTypeDefinition(file, typeName).MetadataToken;
 
-    public static PropertyDefinitionHandle FindProperty(this PEFile file, string typeName, string propertyName)
+    public static PropertyDefinitionHandle FindProperty(this PEFile file, string typeName, string propertyName) =>
+        (PropertyDefinitionHandle)FindPropertyInfo(file, typeName, propertyName).MetadataToken;
+
+    public static IProperty FindPropertyInfo(this PEFile file, string typeName, string propertyName)
     {
         var typeDefinition = file.FindTypeDefinition(typeName);
         var property = typeDefinition.Properties.SingleOrDefault(p => p.Name == propertyName)
                        ?? throw new($"Could not find `{typeName}.{propertyName}` in `{file.FileName}`");
 
-        return (PropertyDefinitionHandle)property.MetadataToken;
+        return property;
     }
 
     public static MethodDefinitionHandle FindMethod(this PEFile file, string typeName, string methodName, Func<IMethod, bool>? predicate = null)

--- a/src/Verify.ICSharpCode.Decompiler/Import/ReflectionDisassembler.cs
+++ b/src/Verify.ICSharpCode.Decompiler/Import/ReflectionDisassembler.cs
@@ -1,4 +1,7 @@
 // ReSharper disable All
+#pragma warning disable IDE0007 // Use implicit type
+#pragma warning disable IDE0003 // Use implicit type
+#pragma warning disable IDE0161 // Use implicit type
 #nullable disable
 
 // Copyright (c) 2011 AlphaSierraPapa for the SharpDevelop Team

--- a/src/Verify.ICSharpCode.Decompiler/PropertyToDisassemble.cs
+++ b/src/Verify.ICSharpCode.Decompiler/PropertyToDisassemble.cs
@@ -1,19 +1,50 @@
+using ICSharpCode.Decompiler.TypeSystem;
+
 namespace VerifyTests;
+
+[Flags]
+public enum PropertyParts
+{
+    /// <summary>
+    /// Disassembles only the property definition
+    /// </summary>
+    Definition = 0,
+    /// <summary>
+    /// Disassembles the property getter
+    /// </summary>
+    Getter = 1,
+    /// <summary>
+    /// Disassembles the property setter
+    /// </summary>
+    Setter = 2,
+    /// <summary>
+    /// Disassembles both the property getter and setter
+    /// </summary>
+    GetterAndSetter = Getter | Setter,
+}
 
 public class PropertyToDisassemble
 {
-    internal readonly PropertyDefinitionHandle Property;
+    internal PropertyDefinitionHandle? PropertyDefinition;
+    internal readonly IProperty? Property;
     internal readonly PEFile File;
+    internal readonly PropertyParts PartsToDisassemble;
 
     public PropertyToDisassemble(PEFile file, PropertyDefinitionHandle property)
     {
-        Property = property;
+        PropertyDefinition = property;
         File = file;
     }
 
-    public PropertyToDisassemble(PEFile file, string typeName, string propertyName)
+    public PropertyToDisassemble(PEFile file, IProperty property, PropertyParts partsToDisassemble = PropertyParts.GetterAndSetter)
     {
-        Property = file.FindProperty(typeName,propertyName);
+        Property = property;
+        PartsToDisassemble = partsToDisassemble;
         File = file;
+    }
+
+    public PropertyToDisassemble(PEFile file, string typeName, string propertyName, PropertyParts partsToDisassemble = default)
+        : this(file, file.FindPropertyInfo(typeName, propertyName), partsToDisassemble)
+    {
     }
 }

--- a/src/Verify.ICSharpCode.Decompiler/VerifyICSharpCodeDecompiler_Property.cs
+++ b/src/Verify.ICSharpCode.Decompiler/VerifyICSharpCodeDecompiler_Property.cs
@@ -3,6 +3,37 @@ namespace VerifyTests;
 public static partial class VerifyICSharpCodeDecompiler
 {
     static ConversionResult ConvertPropertyDefinitionHandle(PropertyToDisassemble property, IReadOnlyDictionary<string, object> context) =>
-        Convert(context, _ => _.DisassembleProperty(property.File, property.Property));
+        Convert(context, disassembler =>
+        {
+            var propertyDefinition = property.PropertyDefinition;
+            if (propertyDefinition.HasValue)
+            {
+                disassembler.DisassembleProperty(property.File, propertyDefinition.Value);
+                return;
+            }
+
+            var propertyInfo = property.Property;
+            if (propertyInfo == null)
+                return;
+
+            var partsToDisassemble = property.PartsToDisassemble;
+            if (partsToDisassemble == PropertyParts.Definition)
+            {
+                disassembler.DisassembleProperty(property.File, (PropertyDefinitionHandle)propertyInfo.MetadataToken);
+                return;
+            }
+
+            var getter = propertyInfo.Getter;
+            var setter = propertyInfo.Setter;
+
+            if (partsToDisassemble.HasFlag(PropertyParts.Getter) && getter != null)
+            {
+                disassembler.DisassembleMethod(property.File, (MethodDefinitionHandle)getter.MetadataToken);
+            }
+            if (partsToDisassemble.HasFlag(PropertyParts.Setter) && setter != null)
+            {
+                disassembler.DisassembleMethod(property.File, (MethodDefinitionHandle)setter.MetadataToken);
+            }
+        });
 
 }


### PR DESCRIPTION
Fix #413: PropertyToDisassemble can disassemble getter and setter methods.